### PR TITLE
Remove sbt-explicit-dependencies plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
     - &lint
       stage: test
       name: Lint
-      script: sbt ++$TRAVIS_SCALA_VERSION scalafmtCheck test:scalafmtCheck scalafmtSbtCheck unusedCompileDependenciesTest
+      script: sbt ++$TRAVIS_SCALA_VERSION scalafmtCheck test:scalafmtCheck scalafmtSbtCheck
     - &test
       stage: test
       name: "Test for 2.12"

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,5 @@ lazy val root = project
   .in(file("."))
   .settings(
     name := "scalaz-ziokeeper",
-    libraryDependencies += "org.scalaz" %% "scalaz-zio" % "0.16",
-    unusedCompileDependenciesFilter -= moduleFilter("com.github.ghik", "silencer-lib")
+    libraryDependencies += "org.scalaz" %% "scalaz-zio" % "0.16"
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,1 @@
 dependsOn(RootProject(uri("git:https://github.com/scalaz/scalaz-sbt.git")))
-
-addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.9")


### PR DESCRIPTION
After integration scala-steward, the plugin started reporting unused
plugin warning for silencer lib. Once ignored via module filter,
scala-steward started failing with report documented [here](https://github.com/fthomas/scala-steward/pull/364#issuecomment-480937458).